### PR TITLE
Fix None being returned for total_population

### DIFF
--- a/testsite/countries/views.py
+++ b/testsite/countries/views.py
@@ -6,7 +6,7 @@ from countries.models import Region
 
 def stats(request):
     regions = Region.objects.annotate(
-        num_countries=Count("countries"), total_population=Sum("countries__population")
+        num_countries=Count("countries"), total_population=Sum("countries__population", default=0)
     )
     response = {"regions": []}
     for region in regions:


### PR DESCRIPTION
### Description
An edge case was found from the addition of Pytests for the stats view function, if a region has no country object belonging to it, the Sum that was ran to aggregate the total population would return `None`. While this inherently doesn't cause any issue with the code to populate the JSON response, this null value doesn't align with the expected format for the data when we reference against the `Country` model.
### Solution
To fix this occurrence, providing a `default` value of `0` to the `Sum` function ensures that in cases where it tries to aggregate with no available country population data, it will instead return the specified integer.